### PR TITLE
通知栏弹窗过高的修复

### DIFF
--- a/src/components/ui/ToastManager.vue
+++ b/src/components/ui/ToastManager.vue
@@ -6,7 +6,7 @@ const store = useNotificationStore();
 </script>
 
 <template>
-  <div class="fixed top-safe left-0 right-0 z-toast pointer-events-none px-4 pt-4 flex flex-col items-center gap-2.5">
+  <div class="vcp-toast-stack fixed left-0 right-0 z-toast pointer-events-none px-4 flex flex-col items-center gap-2.5">
     <TransitionGroup name="toast">
       <ToastItem v-for="toast in store.activeToasts" :key="toast.id" :toast="toast" />
     </TransitionGroup>
@@ -14,6 +14,17 @@ const store = useNotificationStore();
 </template>
 
 <style scoped>
+.vcp-toast-stack {
+  top: calc(var(--vcp-safe-top, env(safe-area-inset-top, 0px)) + 16px);
+}
+
+@media (pointer: coarse) {
+  .vcp-toast-stack {
+    /* Android edge-to-edge WebView often reports safe-area as 0, so keep toasts below the status bar. */
+    top: calc(max(var(--vcp-safe-top, env(safe-area-inset-top, 0px)), 24px) + 12px);
+  }
+}
+
 .toast-enter-active {
   transition: all 0.5s cubic-bezier(0.18, 0.89, 0.32, 1.28);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed toast notification positioning on devices with notches and in WebView environments where safe-area values may be unreliable.

* **Style**
  * Enhanced toast notification styling with improved safe-area inset handling and better support for coarse-pointer touch devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MRiecy/VCPMobile/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->