### PR TITLE
修复 Android 分布式保活前台服务超时闪退

### DIFF
--- a/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/VcpMobilePlugin.kt
+++ b/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/VcpMobilePlugin.kt
@@ -432,18 +432,38 @@ class VcpMobilePlugin(private val activity: Activity) : Plugin(activity) {
             val intent = StreamKeepaliveService.createIntent(activity, args.agentName, args.isKeepaliveMode)
             val hasKeepaliveParam = args.isKeepaliveMode != null
             val isKeepalive = args.isKeepaliveMode ?: false
+            val wasKeepaliveRequested = StreamKeepaliveService.isDistributedKeepaliveRequested ||
+                StreamKeepaliveService.isKeepaliveModeRequested
 
             if (args.agentName.isEmpty()) {
                 if (hasKeepaliveParam) {
                     if (!isKeepalive) {
+                        StreamKeepaliveService.isDistributedKeepaliveRequested = false
+                        StreamKeepaliveService.isTemporaryWakeLockServiceActive = false
+                        StreamKeepaliveService.isKeepaliveModeRequested = false
                         Log.i(TAG, "startStreamingService: both agentName and keepaliveMode are inactive. Stopping service directly.")
                         activity.stopService(intent)
                         invoke.resolve()
                         return
                     }
+                    if (wasKeepaliveRequested && StreamKeepaliveService.isServiceRunning) {
+                        updateRunningService(intent, "startStreamingService: keepalive already active. Updating service without duplicate foreground start.")
+                        StreamKeepaliveService.isDistributedKeepaliveRequested = true
+                        StreamKeepaliveService.isTemporaryWakeLockServiceActive = false
+                        StreamKeepaliveService.isKeepaliveModeRequested = true
+                        invoke.resolve()
+                        return
+                    }
                 } else {
-                    if (StreamKeepaliveService.isServiceRunning) {
-                        startServiceCompatible(intent)
+                    if (StreamKeepaliveService.isKeepaliveModeRequested) {
+                        if (StreamKeepaliveService.isServiceRunning) {
+                            updateRunningService(intent, "startStreamingService: keepalive is active. Clearing stream name without stopping service.")
+                        } else {
+                            Log.i(TAG, "startStreamingService: keepalive is requested but service is not running. Ignoring empty stream stop update.")
+                        }
+                    } else if (StreamKeepaliveService.isServiceRunning) {
+                        Log.i(TAG, "startStreamingService: empty stream update without keepalive. Stopping service directly.")
+                        activity.stopService(intent)
                     }
                     invoke.resolve()
                     return
@@ -460,6 +480,11 @@ class VcpMobilePlugin(private val activity: Activity) : Plugin(activity) {
             }
 
             startServiceCompatible(intent)
+            if (hasKeepaliveParam && isKeepalive) {
+                StreamKeepaliveService.isDistributedKeepaliveRequested = true
+                StreamKeepaliveService.isTemporaryWakeLockServiceActive = false
+                StreamKeepaliveService.isKeepaliveModeRequested = true
+            }
             invoke.resolve()
         } catch (e: Exception) {
             Log.e(TAG, "startStreamingService failed", e)
@@ -468,27 +493,65 @@ class VcpMobilePlugin(private val activity: Activity) : Plugin(activity) {
     }
 
     private fun startServiceCompatible(intent: Intent) {
+        val needsForegroundStart = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !StreamKeepaliveService.isServiceRunning
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (needsForegroundStart) {
                 activity.startForegroundService(intent)
             } else {
                 activity.startService(intent)
             }
-        } catch (e: SecurityException) {
-            Log.w(TAG, "POST_NOTIFICATIONS permission denied, degrading to normal service", e)
-            activity.startService(intent)
+        } catch (e: Exception) {
+            if (!needsForegroundStart) {
+                Log.e(TAG, "startService update failed", e)
+                throw e
+            }
+
+            Log.w(TAG, "startForegroundService failed, trying normal service start", e)
+            try {
+                activity.startService(intent)
+            } catch (fallback: Exception) {
+                Log.e(TAG, "startService fallback failed", fallback)
+                throw fallback
+            }
         }
+    }
+
+    private fun updateRunningService(intent: Intent, message: String) {
+        Log.i(TAG, message)
+        try {
+            activity.startService(intent)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update running StreamKeepaliveService", e)
+            throw e
+        }
+    }
+
+    private fun shouldKeepDistributedService(): Boolean {
+        return StreamKeepaliveService.isDistributedKeepaliveRequested ||
+            (StreamKeepaliveService.isKeepaliveModeRequested &&
+                !StreamKeepaliveService.isTemporaryWakeLockServiceActive)
     }
 
     @Command
     fun stopStreamingService(invoke: Invoke) {
         try {
             val intent = StreamKeepaliveService.createIntent(activity, "")
+            val keepDistributedService = shouldKeepDistributedService()
 
             // 联动取消屏幕高亮常亮
             isScreenKeepOnActive = false
             activity.runOnUiThread {
                 activity.window.clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+
+            if (keepDistributedService) {
+                if (StreamKeepaliveService.isServiceRunning) {
+                    updateRunningService(intent, "stopStreamingService: distributed keepalive is active. Clearing stream name without stopping service.")
+                } else {
+                    Log.i(TAG, "stopStreamingService: distributed keepalive is requested but service is not running.")
+                }
+                invoke.resolve()
+                return
             }
 
             activity.stopService(intent)
@@ -502,8 +565,16 @@ class VcpMobilePlugin(private val activity: Activity) : Plugin(activity) {
     @Command
     fun acquireWakeLock(invoke: Invoke) {
         try {
+            if (StreamKeepaliveService.isServiceRunning) {
+                Log.i(TAG, "acquireWakeLock: keepalive service already running. Skipping duplicate foreground service start.")
+                invoke.resolve()
+                return
+            }
+            val shouldOwnTemporaryService = !StreamKeepaliveService.isDistributedKeepaliveRequested
             val intent = StreamKeepaliveService.createIntent(activity, "[后台保活]", true)
             startServiceCompatible(intent)
+            StreamKeepaliveService.isKeepaliveModeRequested = true
+            StreamKeepaliveService.isTemporaryWakeLockServiceActive = shouldOwnTemporaryService
             invoke.resolve()
         } catch (e: Exception) {
             Log.e(TAG, "acquireWakeLock failed", e)
@@ -514,6 +585,23 @@ class VcpMobilePlugin(private val activity: Activity) : Plugin(activity) {
     @Command
     fun releaseWakeLock(invoke: Invoke) {
         try {
+            val keepDistributedService = shouldKeepDistributedService()
+
+            if (keepDistributedService) {
+                StreamKeepaliveService.isTemporaryWakeLockServiceActive = false
+                Log.i(TAG, "releaseWakeLock: distributed keepalive is active. Keeping foreground service running.")
+                invoke.resolve()
+                return
+            }
+
+            if (!StreamKeepaliveService.isTemporaryWakeLockServiceActive) {
+                Log.i(TAG, "releaseWakeLock: no temporary wake-lock service to release.")
+                invoke.resolve()
+                return
+            }
+
+            StreamKeepaliveService.isTemporaryWakeLockServiceActive = false
+            StreamKeepaliveService.isKeepaliveModeRequested = false
             val intent = StreamKeepaliveService.createIntent(activity, "", false)
             activity.stopService(intent)
             invoke.resolve()

--- a/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/service/StreamKeepaliveService.kt
+++ b/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/service/StreamKeepaliveService.kt
@@ -42,6 +42,15 @@ class StreamKeepaliveService : Service() {
         @Volatile
         var isServiceRunning = false
 
+        @Volatile
+        var isKeepaliveModeRequested = false
+
+        @Volatile
+        var isDistributedKeepaliveRequested = false
+
+        @Volatile
+        var isTemporaryWakeLockServiceActive = false
+
         /**
          * 构造启动该服务的 Intent
          */
@@ -66,48 +75,29 @@ class StreamKeepaliveService : Service() {
         if (intent != null) {
             if (intent.hasExtra(EXTRA_IS_KEEPALIVE_MODE)) {
                 isKeepaliveModeActive = intent.getBooleanExtra(EXTRA_IS_KEEPALIVE_MODE, false)
+                isKeepaliveModeRequested = isKeepaliveModeActive
             }
             if (intent.hasExtra(EXTRA_AGENT_NAME)) {
                 currentStreamName = intent.getStringExtra(EXTRA_AGENT_NAME) ?: ""
             }
         }
 
-        if (!isKeepaliveModeActive && currentStreamName.isEmpty()) {
-            Log.i(TAG, "No active streams and keepalive mode is inactive. Stopping service safely.")
-            val notification = buildNotification("", false)
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                    startForeground(
-                        NOTIFICATION_ID,
-                        notification,
-                        ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
-                    )
-                } else {
-                    startForeground(NOTIFICATION_ID, notification)
-                }
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to startForeground during shutdown fallback", e)
-            }
-            stopSelf()
+        val shouldStop = !isKeepaliveModeActive && currentStreamName.isEmpty()
+        val notification = buildNotification(currentStreamName, isKeepaliveModeActive)
+
+        if (!promoteToForeground(notification)) {
+            Log.e(TAG, "Foreground promotion failed. Stopping service to satisfy Android foreground-service contract.")
+            stopSelf(startId)
             return START_NOT_STICKY
         }
 
-        val notification = buildNotification(currentStreamName, isKeepaliveModeActive)
-
-        // Android 14+ 必须声明前台服务类型，且加 try-catch 兜底，防止 ForegroundServiceStartNotAllowedException
-        try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                startForeground(
-                    NOTIFICATION_ID,
-                    notification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
-                )
-            } else {
-                startForeground(NOTIFICATION_ID, notification)
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to startForeground, falling back to basic background service", e)
+        if (shouldStop) {
+            Log.i(TAG, "No active streams and keepalive mode is inactive. Stopping service safely.")
+            stopSelf(startId)
+            return START_NOT_STICKY
         }
+
+        Log.i(TAG, "Foreground service active: stream='$currentStreamName', keepalive=$isKeepaliveModeActive")
 
         if (isKeepaliveModeActive || currentStreamName.isNotEmpty()) {
             val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
@@ -143,6 +133,24 @@ class StreamKeepaliveService : Service() {
         }
 
         return START_STICKY
+    }
+
+    private fun promoteToForeground(notification: Notification): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_REMOTE_MESSAGING
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "startForeground failed", e)
+            false
+        }
     }
 
     override fun onDestroy() {

--- a/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/service/StreamKeepaliveService.kt
+++ b/src-tauri/plugins/vcp-mobile/android/src/main/java/com/vcp/mobile/service/StreamKeepaliveService.kt
@@ -175,6 +175,9 @@ class StreamKeepaliveService : Service() {
         wifiLock = null
 
         isServiceRunning = false
+        isKeepaliveModeRequested = false
+        isDistributedKeepaliveRequested = false
+        isTemporaryWakeLockServiceActive = false
         super.onDestroy()
     }
 


### PR DESCRIPTION
## 背景

在 Android 12+ / targetSdk 36 环境下，开启分布式节点后，应用会在一段时间后因为前台服务启动契约超时而闪退。真机 logcat 中可以看到 `ForegroundServiceDidNotStartInTimeException`，并伴随 `Context.startForegroundService() did not then call Service.startForeground`。

实际复现链路里，分布式保活服务先进入前台，但随后 `releaseWakeLock` / 空 stream 更新路径会取消或停止同一个 `StreamKeepaliveService`。之后分布式定时任务再次触发 `[后台保活]` 路径，导致系统认为前台服务未及时完成 `startForeground`，最终抛出 FGS 超时异常。

## 修复内容

- 让 `StreamKeepaliveService` 在 `onStartCommand` 中先完成 `startForeground`，再判断是否需要停止，满足 Android 前台服务启动契约。
- 将分布式常驻保活和临时 wake lock 保活的状态拆开，避免 `releaseWakeLock` 误停由 `set_keepalive_mode(true)` 启动的分布式前台服务。
- 避免服务已经运行时重复调用 `startForegroundService`，改为普通 `startService` 更新运行中的前台服务。
- 保护空 `agentName` 的 stream stop/update 路径：分布式保活开启时只清空 stream 名称，不停止前台服务。
- 将保活 owner 状态放在 `StreamKeepaliveService` companion 中，避免 Activity/Plugin 重建后临时状态丢失造成误判。

## 验证

已在本地完成：

- `./gradlew.bat :tauri-plugin-vcp-mobile:compileReleaseKotlin`
- `pnpm tauri android build --apk --target aarch64`
- ADB 覆盖安装到真机并启动应用
- 开启分布式后抓取 105 秒 logcat

真机复测结果：

- `FATAL EXCEPTION`: 0
- `ForegroundServiceDidNotStartInTimeException`: 0
- `RemoteServiceException`: 0
- `Cancel FGS notification`: 0
- `Bringing down service while still waiting for start foreground`: 0

服务状态确认：`StreamKeepaliveService` 保持 `isForeground=true`，foreground type 为 `remoteMessaging`，通知未被取消。

关键日志包含：

```text
Foreground service active: stream='', keepalive=true
acquireWakeLock: keepalive service already running. Skipping duplicate foreground service start.
releaseWakeLock: distributed keepalive is active. Keeping foreground service running.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background streaming stability by preventing duplicate foreground/keepalive service starts and better coordinating keepalive and stream state transitions.
  * Enhanced stop/start behavior so the keepalive foreground service remains active when distributed keepalive should continue, reducing unexpected interruptions.

* **Performance**
  * Optimized wake-lock acquisition and release logic to avoid unnecessary work and better manage temporary wake-lock behavior during background streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->